### PR TITLE
Separate rulesets into subdirectories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,11 @@ module github.com/fabianvf/windup-rulesets-yaml
 go 1.18
 
 require (
-	github.com/konveyor/analyzer-lsp v0.0.0-20230308220021-9207271093c7
+	github.com/konveyor/analyzer-lsp v0.0.0-20230425160515-1aa8dbd6d205
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
-github.com/konveyor/analyzer-lsp v0.0.0-20230308220021-9207271093c7 h1:BuVQPbldpigjjybuenqjba7zozKRDFc6ytsuzJyDVtM=
-github.com/konveyor/analyzer-lsp v0.0.0-20230308220021-9207271093c7/go.mod h1:1IakV7HXp1RRzRKm9jI7n5faYKexNm9eRfbmTHiLaXM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+github.com/konveyor/analyzer-lsp v0.0.0-20230425160515-1aa8dbd6d205 h1:7iyMMPlMfIHnSReblGAq+S/xhEYBiPXlgKhcKEEKvm0=
+github.com/konveyor/analyzer-lsp v0.0.0-20230425160515-1aa8dbd6d205/go.mod h1:4XzJtxxf8NDSV/9Lv+NiUA1JlAyUpc3RaHEWfXkwPig=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -100,9 +100,9 @@ func main() {
 				if err != nil {
 					fmt.Println(err)
 				}
+				output, dir, err := execution.ExecuteRulesets(rulesets, location, data)
+				fmt.Println(output, dir, err)
 			}
-			output, dir, err := execution.ExecuteRulesets(rulesets, data)
-			fmt.Println(output, dir, err)
 		}
 	default:
 		fmt.Println(help)

--- a/pkg/conversion/convert.go
+++ b/pkg/conversion/convert.go
@@ -457,7 +457,7 @@ func convertWindupPerformToAnalyzer(perform windup.Iteration, where map[string]s
 
 	if perform.Hint != nil {
 		if len(perform.Hint) != 1 {
-			// TODO"github.com/russross/blackfriday/v2"
+			// TODO
 			panic("More than one hint in a rule")
 			return nil
 		}

--- a/pkg/conversion/convert.go
+++ b/pkg/conversion/convert.go
@@ -23,7 +23,7 @@ func ConvertWindupRulesetsToAnalyzer(windups []windup.Ruleset, baseLocation, out
 		ruleset := ConvertWindupRulesetToAnalyzer(windupRuleset)
 		rulesetRelativePath := strings.Trim(strings.Replace(strings.Replace(windupRuleset.SourceFile, baseLocation, "", 1), filepath.Base(windupRuleset.SourceFile), "", 1), "/")
 		rulesetFileName := strings.Replace(filepath.Base(windupRuleset.SourceFile), ".xml", ".yaml", 1)
-		yamlPath := filepath.Join(outputDir, rulesetRelativePath, fmt.Sprintf("%.02d-%s", idx, strings.Replace(rulesetFileName, ".windup.yaml", "", 1)), rulesetFileName)
+		yamlPath := filepath.Join(outputDir, rulesetRelativePath, fmt.Sprintf("%.02d-%s", idx+1, strings.Replace(rulesetFileName, ".windup.yaml", "", 1)), rulesetFileName)
 		if reflect.DeepEqual(ruleset, map[string]interface{}{}) {
 			continue
 		}

--- a/pkg/conversion/convert.go
+++ b/pkg/conversion/convert.go
@@ -19,11 +19,11 @@ type analyzerRules struct {
 
 func ConvertWindupRulesetsToAnalyzer(windups []windup.Ruleset, baseLocation, outputDir string) (map[string]*analyzerRules, error) {
 	outputRulesets := map[string]*analyzerRules{}
-	for _, windupRuleset := range windups {
+	for idx, windupRuleset := range windups {
 		ruleset := ConvertWindupRulesetToAnalyzer(windupRuleset)
 		rulesetRelativePath := strings.Trim(strings.Replace(strings.Replace(windupRuleset.SourceFile, baseLocation, "", 1), filepath.Base(windupRuleset.SourceFile), "", 1), "/")
 		rulesetFileName := strings.Replace(filepath.Base(windupRuleset.SourceFile), ".xml", ".yaml", 1)
-		yamlPath := filepath.Join(outputDir, rulesetRelativePath, strings.Replace(rulesetFileName, ".windup.yaml", "", 1), rulesetFileName)
+		yamlPath := filepath.Join(outputDir, rulesetRelativePath, fmt.Sprintf("%.02d-%s", idx, strings.Replace(rulesetFileName, ".windup.yaml", "", 1)), rulesetFileName)
 		if reflect.DeepEqual(ruleset, map[string]interface{}{}) {
 			continue
 		}

--- a/pkg/execution/execute.go
+++ b/pkg/execution/execute.go
@@ -130,14 +130,8 @@ func ExecuteRulesets(rulesets []windup.Ruleset, baseLocation, datadir string) (s
 	if err != nil {
 		return "", "", err
 	}
-	os.Mkdir(filepath.Join(dir, "rules"), os.ModePerm)
 	fmt.Println(dir)
-	// Write base discovery rule to disk
-	err = os.WriteFile(filepath.Join(dir, "rules", "0.yaml"), []byte(BASE_DISCOVERY_RULES), 0666)
-	if err != nil {
-		return "", dir, err
-	}
-	err = writeYAML(map[string]interface{}{"name": "test-ruleset"}, filepath.Join(dir, "rules", "ruleset.yaml"))
+	err = createDefaultRuleset(dir)
 	if err != nil {
 		return "", dir, err
 	}
@@ -183,6 +177,24 @@ func ExecuteRulesets(rulesets []windup.Ruleset, baseLocation, datadir string) (s
 	writeYAML(debugInfo, filepath.Join(dir, "debug.yaml"))
 
 	return string(stdout), dir, err
+}
+
+func createDefaultRuleset(dir string) error {
+	defaultRulesetPath := filepath.Join(dir, "rules", "00-default")
+	err := os.MkdirAll(defaultRulesetPath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	// Write base discovery rule to disk
+	err = os.WriteFile(filepath.Join(defaultRulesetPath, "0.yaml"), []byte(BASE_DISCOVERY_RULES), 0666)
+	if err != nil {
+		return err
+	}
+	err = writeYAML(map[string]interface{}{"name": "test-ruleset"}, filepath.Join(defaultRulesetPath, "ruleset.yaml"))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func writeYAML(content interface{}, dest string) error {

--- a/pkg/windup/types.go
+++ b/pkg/windup/types.go
@@ -1,5 +1,11 @@
 package windup
 
+import (
+	"encoding/xml"
+	"regexp"
+	"strings"
+)
+
 type Addon struct {
 	Id string `xml:"id,attr,omitempty" yaml:"id,omitempty"`
 }
@@ -227,7 +233,7 @@ type Matches struct {
 }
 
 type Metadata struct {
-	Description      string       `xml:"description,omitempty" yaml:"description,omitempty"`
+	Description      Description  `xml:"description,omitempty" yaml:"description,omitempty"`
 	Dependencies     Dependencies `xml:"dependencies" yaml:"dependencies"`
 	SourceTechnology []Technology `xml:"sourceTechnology,omitempty" yaml:"sourceTechnology,omitempty"`
 	TargetTechnology []Technology `xml:"targetTechnology,omitempty" yaml:"targetTechnology,omitempty"`
@@ -236,6 +242,21 @@ type Metadata struct {
 	ExecuteBefore    []string     `xml:"executeBefore,omitempty" yaml:"executeBefore,omitempty"`
 	Tag              []string     `xml:"tag,omitempty" yaml:"tag,omitempty"`
 	OverrideRules    bool         `xml:"overrideRules,omitempty" yaml:"overrideRules,omitempty"`
+}
+
+type Description string
+
+func (d *Description) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error {
+	var val string
+	err := decoder.DecodeElement(&val, &start)
+	if err != nil {
+		return err
+	}
+	val = strings.Replace(val, "\n", "", 1)
+	val = regexp.MustCompile(`\s+`).ReplaceAllString(val, " ")
+	val = strings.Trim(val, " ")
+	*d = Description(val)
+	return nil
 }
 
 type Namespace struct {
@@ -294,7 +315,7 @@ type Rules struct {
 }
 
 type Ruleset struct {
-	Metadata        []Metadata        `xml:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Metadata        Metadata          `xml:"metadata,omitempty" yaml:"metadata,omitempty"`
 	Rules           Rules             `xml:"rules" yaml:"rules"`
 	Packagemapping  []Mapping         `xml:"package-mapping,omitempty" yaml:"package-mapping,omitempty"`
 	Filemapping     []Mapping         `xml:"file-mapping,omitempty" yaml:"file-mapping,omitempty"`


### PR DESCRIPTION
`<output_dir>/openshift/embedded-cache-libraries.windup.xml` ruleset will now go in `<output_dir>/openshift/embedded-cache-libraries/embedded-cache-libraries.windup.yaml` 

Each ruleset is separated under its own new sub-directory with an added `ruleset.yaml` file 