### PR TITLE
Add more fields along with some other ruleset fixes

### DIFF
--- a/pkg/conversion/convert_test.go
+++ b/pkg/conversion/convert_test.go
@@ -46,6 +46,16 @@ func Test_parseMavenVersionRange(t *testing.T) {
 			verRange: "[6,)",
 			want:     []string{"6+"},
 		},
+		{
+			name:     "case 8",
+			verRange: "[6]",
+			want:     []string{"6"},
+		},
+		{
+			name:     "case 9",
+			verRange: "[2.0,2.1,2.2,2.3]",
+			want:     []string{"2"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Converts `hint.Link` and `classification.Link` to `rule.Links`
- Adds `hint.Title` and `classification.Title` as first line in the description
- Appends message to description when it isn't templated
- Fixes ruleset versions that float values
- Fixes ordering of technology-usage rulesets to make them run at end in given directory
Fixes #36 

Analyzer PR: 211