### PR TITLE
:sparkles: Rules conversion fixes for adding include=always label 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fabianvf/windup-rulesets-yaml
 go 1.18
 
 require (
-	github.com/konveyor/analyzer-lsp v0.0.0-20230717225202-ba6d8da016c1
+	github.com/konveyor/analyzer-lsp v0.3.0-beta.1
 	go.lsp.dev/uri v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
 github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
-github.com/konveyor/analyzer-lsp v0.0.0-20230706210035-2fee76eb8e4f h1:qX3lPYvhMox5J68hM6es34QVz5QW2bIyU+qyduqqNp8=
-github.com/konveyor/analyzer-lsp v0.0.0-20230706210035-2fee76eb8e4f/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
-github.com/konveyor/analyzer-lsp v0.0.0-20230717225202-ba6d8da016c1 h1:ayGO4il6x3cb/CakkTZVUmAjteBzTiOvrVTlarlfUd4=
-github.com/konveyor/analyzer-lsp v0.0.0-20230717225202-ba6d8da016c1/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
+github.com/konveyor/analyzer-lsp v0.3.0-beta.1 h1:tAQ7e/2z+eoLERhawXOont9XA2kqYa3BaqVreaFYBtE=
+github.com/konveyor/analyzer-lsp v0.3.0-beta.1/go.mod h1:dhFFu6r2W7xIm90T2x0CaUqDh/BkFMeDmYTgVxKJn18=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	var failFast, flattenRulesets bool
 	convertCmd := flag.NewFlagSet("convert", flag.ExitOnError)
 	convertCmd.StringVar(&outputDir, "outputdir", "analyzer-lsp-rules", "The output location for converted rules")
-	convertCmd.BoolVar(&flattenRulesets, "flatten", false, "Preserve original ruleset structure of windup rules")
+	convertCmd.BoolVar(&flattenRulesets, "flatten", true, "Preserve original ruleset structure of windup rules")
 	testCmd := flag.NewFlagSet("test", flag.ExitOnError)
 	testCmd.BoolVar(&failFast, "fail-fast", false, "If true, fail on first test failure")
 	runCmd := flag.NewFlagSet("run", flag.ExitOnError)

--- a/pkg/conversion/convert.go
+++ b/pkg/conversion/convert.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fabianvf/windup-rulesets-yaml/pkg/windup"
 	"github.com/konveyor/analyzer-lsp/engine"
+	engineLabels "github.com/konveyor/analyzer-lsp/engine/labels"
 	"github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"gopkg.in/yaml.v2"
 )
@@ -244,11 +245,20 @@ func getRulesetLabels(m windup.Metadata) []string {
 		labels = append(labels,
 			fmt.Sprintf("%s=%s", konveyor.TargetTechnologyLabel, targetTech.Id))
 	}
-	if m.SourceTechnology == nil || len(m.SourceTechnology) == 0 {
-		labels = append(labels, konveyor.SourceTechnologyLabel)
-	}
-	if m.TargetTechnology == nil || len(m.TargetTechnology) == 0 {
-		labels = append(labels, konveyor.TargetTechnologyLabel)
+	// when both source technology and target technology is absent, this rule
+	// was run all the time in windup, add explicit wildcard label on it
+	if (m.SourceTechnology == nil && m.TargetTechnology == nil) ||
+		(m.SourceTechnology != nil && len(m.SourceTechnology) == 0 &&
+			m.TargetTechnology != nil && len(m.TargetTechnology) == 0) {
+		labels = append(labels, fmt.Sprintf("%s=%s",
+			engineLabels.RuleIncludeLabel, engineLabels.SelectAlways))
+	} else {
+		if m.SourceTechnology == nil || len(m.SourceTechnology) == 0 {
+			labels = append(labels, konveyor.SourceTechnologyLabel)
+		}
+		if m.TargetTechnology == nil || len(m.TargetTechnology) == 0 {
+			labels = append(labels, konveyor.TargetTechnologyLabel)
+		}
 	}
 	// rulesets have <tags> too
 	labels = append(labels, m.Tag...)

--- a/pkg/conversion/rules.go
+++ b/pkg/conversion/rules.go
@@ -1,6 +1,8 @@
 package conversion
 
-import "strings"
+import (
+	"strings"
+)
 
 // TODO: scope license file search to LICENSE files and use templates for tags to convert individual rules into one rule
 const license_rules = `
@@ -8,6 +10,8 @@ const license_rules = `
   description: "Discover project license"
   tag:
   - License={{matchingText}}
+  labels:
+  - konveyor.io/include=always
   when:
     or:
     - builtin.filecontent:
@@ -48,24 +52,32 @@ const java_rules = `
   message: "When migrating environments, hard-coded IP addresses may need to be modified or eliminated."
 - ruleID: discover-properties-file
   description: "Properties file"
+  labels:
+  - konveyor.io/include=always
   when:
     builtin.file:
       pattern: "^.*\\.properties$"
   tag: ["Properties"]
 - ruleID: discover-manifest-file
   description: "Manifest file"
+  labels:
+  - konveyor.io/include=always
   when:
     builtin.file:
       pattern: "MANIFEST.MF"
   tag: ["Manifest"]
 - ruleID: discover-java-files
   description: "Java source files"
+  labels:
+  - konveyor.io/include=always
   when:
     builtin.file:
       pattern: "*.java"
   tag: ["Java Source"]
 - ruleID: discover-maven-xml
   description: "Maven XML file"
+  labels:
+  - konveyor.io/include=always
   when:
     builtin.file:
       pattern: "pom.xml"
@@ -74,18 +86,23 @@ const java_rules = `
 
 const java_ee_rules = `
 - ruleID: windup-discover-ejb-configuration
+  labels:
+  - konveyor.io/include=always
   tag: ["EJB XML"]
   when:
     builtin.xml:
       xpath: "/(jboss:ejb-jar or ejb-jar)"
 - ruleID: windup-discover-spring-configuration
   tag: ["Spring XML"]
+  labels:
+  - konveyor.io/include=always
   when:
     builtin.xml:
       xpath: "/beans"
 - ruleID: windup-discover-jpa-configuration
   tag: ["JPA XML"]
-  message: "Persistence unit"
+  labels:
+  - konveyor.io/include=always
   when:
     or:
       - builtin.xml:
@@ -95,6 +112,8 @@ const java_ee_rules = `
       - builtin.xml:
           xpath: '/persistence[boolean(namespace-uri(/persistence)="https://jakarta.ee/xml/ns/persistence")]'
 - ruleID: windup-discover-web-configuration
+  labels:
+  - konveyor.io/include=always
   tag: ["Web XML"]
   when:
     # TODO extract version as in rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
@@ -115,7 +134,5 @@ func GetDiscoveryRuleset() string {
 name: discovery-rules
 labels:
 - discovery
-- konveyor.io/source
-- konveyor.io/target
 `
 }


### PR DESCRIPTION
Also flattening the rules by default, as thats what we are doing for generating rulesets for seeding