### PR TITLE
:bug: Trim extra newlines in messages

### DIFF
--- a/pkg/conversion/convert.go
+++ b/pkg/conversion/convert.go
@@ -884,7 +884,8 @@ func substituteWhere(where map[string]string, pattern string) string {
 
 func trimMessage(s string) string {
 	re := regexp.MustCompile(`( ){2,}`)
-	return re.ReplaceAllString(s, " ")
+	trimmed := strings.TrimSpace(s)
+	return re.ReplaceAllString(trimmed, " ")
 }
 
 func flattenWhere(wheres []windup.Where) map[string]string {

--- a/pkg/conversion/convert_test.go
+++ b/pkg/conversion/convert_test.go
@@ -112,3 +112,29 @@ func Test_convertMessageString(t *testing.T) {
 		})
 	}
 }
+
+func Test_trimMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{
+			name: "message with trailing and ending newlines",
+			msg:  "\n\ntest    message\n\n",
+			want: "test message",
+		},
+		{
+			name: "message with newlines in the middle",
+			msg:  "\n\ntest \n message\n\n",
+			want: "test \n message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimMessage(tt.msg); got != tt.want {
+				t.Errorf("convertMessageString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Conversion of windup rules often has unnecessary extra newlines at the beginning and end. This removes them.