### PR TITLE
e:ghost: drop pp64le and s390x architecture support

### DIFF
--- a/.github/workflows/multi-arch_images_build.yaml
+++ b/.github/workflows/multi-arch_images_build.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout Push to Registry action
       uses: konveyor/release-tools/build-push-quay@main
       with:
-        architectures: "amd64, arm64, ppc64le, s390x"
+        architectures: "amd64, arm64"
         containerfile: "./core.Dockerfile"
         image_name: "windup-shim"
         image_namespace: "konveyor"


### PR DESCRIPTION
Limiting ourselves to only what the java-external-provider supports.